### PR TITLE
Cache server version per kubeconfig

### DIFF
--- a/k
+++ b/k
@@ -2,8 +2,25 @@
 set +x
 
 KX_PATH="$HOME/.kx"
-mkdir -p "$KX_PATH"
-TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+mkdir -p "$KX_PATH/cache"
+
+# Attempt to load the server version from cache
+if [ ! -z "$KUBECONFIG" ]; then
+  KUBECONFIG_HASH=$(echo "$KUBECONFIG" | sha256sum | cut -c1-5)
+  VERSION_CACHE_FILE="$KX_PATH/cache/$KUBECONFIG_HASH"
+  TARGET_VERSION=$(cat "$VERSION_CACHE_FILE" 2> /dev/null)
+fi
+
+# Get the server version from the server if not cached
+if [ -z "$TARGET_VERSION" ]; then
+  TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+fi
+
+# Fill the cache if possible
+if [ ! -z "$KUBECONFIG" ]; then
+  echo "$TARGET_VERSION" > "$VERSION_CACHE_FILE"
+fi
+
 TARGET=$KX_PATH/kubectl-$TARGET_VERSION
 
 if [ ! -f $TARGET ]; then


### PR DESCRIPTION
Resolves #1 

This adds logic to cache the corresponding server version for a given
kubeconfig. Makes for a snappier dev experience by avoiding `kubectl
version`'s API call.