### PR TITLE
Allow downloading of Linux and Windows binaries

### DIFF
--- a/k
+++ b/k
@@ -4,9 +4,24 @@ set +x
 KX_PATH="$HOME/.kx"
 mkdir -p "$KX_PATH/cache"
 
+case "$OSTYPE" in
+  *arwin*)
+    OS="darwin"
+    ;;
+  *in32* | *indows*)
+    OS="windows"
+    ;;
+  *)
+    OS="linux"
+esac
+
 # Attempt to load the server version from cache
 if [ ! -z "$KUBECONFIG" ]; then
-  KUBECONFIG_HASH=$(echo "$KUBECONFIG" | sha256sum | cut -c1-5)
+  if [ "$OS" == "darwin" ]; then
+    KUBECONFIG_HASH=$(echo "$KUBECONFIG" | shasum -a 256 | cut -c1-5)
+  else
+    KUBECONFIG_HASH=$(echo "$KUBECONFIG" | sha256sum | cut -c1-5)
+  fi
   VERSION_CACHE_FILE="$KX_PATH/cache/$KUBECONFIG_HASH"
   TARGET_VERSION=$(cat "$VERSION_CACHE_FILE" 2> /dev/null)
 fi
@@ -25,7 +40,7 @@ TARGET=$KX_PATH/kubectl-$TARGET_VERSION
 
 if [ ! -f $TARGET ]; then
   cd "$KX_PATH"
-  curl -LO "https://storage.googleapis.com/kubernetes-release/release/$TARGET_VERSION/bin/darwin/amd64/kubectl"
+  curl -LO "https://storage.googleapis.com/kubernetes-release/release/$TARGET_VERSION/bin/$OS/amd64/kubectl"
   mv $KX_PATH/kubectl $TARGET
   chmod +x $TARGET
 fi


### PR DESCRIPTION
The `kubectl` download path had `darwin` harcoded in there. This change seems to work from Ubuntu inside a docker container.