### PR TITLE
Add set +e to return non 0 if any command fails

### DIFF
--- a/k
+++ b/k
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +x
+set +xe
 
 KX_PATH="$HOME/.kx"
 mkdir -p "$KX_PATH/cache"


### PR DESCRIPTION
If you've exported `KUBECONFIG` to a file that does not exist, the version command fails but then the invalid version is cached for the invalid kubeconfig file. By simply setting `+e`, when the `kubectl version` call fails, the command will just exit, which is the desired behavior.