### PR TITLE
feat: support clusters built from source

### DIFF
--- a/k
+++ b/k
@@ -28,7 +28,11 @@ fi
 
 # Get the server version from the server if not cached
 if [ -z "$TARGET_VERSION" ]; then
-  TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-4)
+  if [ $(echo $TARGET_VERSION | egrep "alpha|beta|rc") ]; then
+    TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-4)
+  else
+    TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-3)
+  fi
 fi
 
 # Fill the cache if possible

--- a/k
+++ b/k
@@ -28,7 +28,7 @@ fi
 
 # Get the server version from the server if not cached
 if [ -z "$TARGET_VERSION" ]; then
-  TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+  TARGET_VERSION=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-4)
 fi
 
 # Fill the cache if possible


### PR DESCRIPTION
It would be even *more* convenient if we could use `k` to establish hygienic client/server connections against cluster built from source. For example:

```
$ kubectl version -o json | jq -r '.serverVersion.gitVersion'
v1.17.0-alpha.2.150+b9c06a8038ab70-dirt
```

Google won't ever publish a `kubectl` binary for the above commit hash.

This PR does a little string mangling to include only the significant chars we want in order to reliably grab artifacts from google storage.