### PR TITLE
EKS Support (and QOL minor changes)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.sh]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*.sh]
-charset = utf-8
-indent_style = space
-indent_size = 2
-end_of_line = lf
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/k
+++ b/k
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +xe
+set -xe
 
 KX_PATH="${KX_PATH:-$HOME/.kx}"
 mkdir -p "$KX_PATH/cache"
@@ -16,7 +16,7 @@ case "$OSTYPE" in
 esac
 
 # Attempt to load the server version from cache
-if [ ! -z "$KUBECONFIG" ]; then
+if [ -n "$KUBECONFIG" ]; then
   if [ "$OS" == "darwin" ]; then
     KUBECONFIG_HASH=$(echo "$KUBECONFIG" | shasum -a 256 | cut -c1-5)
   else
@@ -40,12 +40,12 @@ case $CPU_ARCHITECTURE in
 esac
 
 # Ensure we have at least 1 kubectl version
-KNOWN_VERSION="v1.16.3"
+#
+# This is used to make it easier to get the server version, which
+# is an API that rarely changes... at least that is the hope
+KNOWN_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
 LOCAL_KUBECTL=$KX_PATH/kubectl-$KNOWN_VERSION
-KUBECTL_PATH=$(command -v kubectl)
-if [ ! -z "$KUBECTL_PATH" ]; then
-  LOCAL_KUBECTL=$KUBECTL_PATH
-elif [ ! -f "$LOCAL_KUBECTL" ]; then
+if [ ! -f "$LOCAL_KUBECTL" ]; then
   curl -L -o "$LOCAL_KUBECTL" "https://storage.googleapis.com/kubernetes-release/release/$KNOWN_VERSION/bin/$OS/$CPU_ARCHITECTURE/kubectl"
   chmod +x "$LOCAL_KUBECTL"
 fi
@@ -57,15 +57,23 @@ if [ -z "$TARGET_VERSION" ]; then
     echo "Unable to get version information from cluster"
     exit 1
   fi
-  if [ $(echo $TARGET_VERSION | egrep "alpha|beta|rc") ]; then
+  # watch out for different non-stable release versions
+  if echo "$TARGET_VERSION" | grep -E "alpha|beta|rc"
+  then
     TARGET_VERSION=$(echo $TARGET_VERSION | cut -d'.' -f1-4)
   else
     TARGET_VERSION=$(echo $TARGET_VERSION | cut -d'.' -f1-3)
   fi
+
+  # watch out for the custom EKS version
+  if echo "$TARGET_VERSION" | grep -E "eks"
+  then
+    TARGET_VERSION=$(echo $TARGET_VERSION | cut -d'-' -f1)
+  fi
 fi
 
 # Fill the cache if possible
-if [ ! -z "$KUBECONFIG" ]; then
+if [ -n "$KUBECONFIG" ]; then
   echo "$TARGET_VERSION" > "$VERSION_CACHE_FILE"
 fi
 

--- a/k
+++ b/k
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
-set -xe
+set +xe
+
+# DEBUG
+# true => verbose (`set -xe`)
+# <anything_else> => nothing
+DEBUG=${DEBUG:-false}
+
+if [[ "$DEBUG" == "true" ]];
+then
+  set -xe
+  echo "Enabled verbose logging."
+fi
+
 
 KX_PATH="${KX_PATH:-$HOME/.kx}"
 mkdir -p "$KX_PATH/cache"
@@ -46,7 +58,7 @@ esac
 KNOWN_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
 LOCAL_KUBECTL=$KX_PATH/kubectl-$KNOWN_VERSION
 if [ ! -f "$LOCAL_KUBECTL" ]; then
-  curl -L -o "$LOCAL_KUBECTL" "https://storage.googleapis.com/kubernetes-release/release/$KNOWN_VERSION/bin/$OS/$CPU_ARCHITECTURE/kubectl"
+  curl -L -o "$LOCAL_KUBECTL" "https://storage.googleapis.com/kubernetes-release/release/$KNOWN_VERSION/bin/$OS/$CPU_ARCHITECTURE/kubectl" > /dev/null 2>&1
   chmod +x "$LOCAL_KUBECTL"
 fi
 
@@ -58,7 +70,7 @@ if [ -z "$TARGET_VERSION" ]; then
     exit 1
   fi
   # watch out for different non-stable release versions
-  if echo "$TARGET_VERSION" | grep -E "alpha|beta|rc"
+  if echo "$TARGET_VERSION" | grep -E "alpha|beta|rc" > /dev/null 2>&1
   then
     TARGET_VERSION=$(echo $TARGET_VERSION | cut -d'.' -f1-4)
   else
@@ -66,7 +78,7 @@ if [ -z "$TARGET_VERSION" ]; then
   fi
 
   # watch out for the custom EKS version
-  if echo "$TARGET_VERSION" | grep -E "eks"
+  if echo "$TARGET_VERSION" | grep -E "eks" > /dev/null 2>&1
   then
     TARGET_VERSION=$(echo $TARGET_VERSION | cut -d'-' -f1)
   fi
@@ -80,7 +92,7 @@ fi
 TARGET=$KX_PATH/kubectl-$TARGET_VERSION
 
 if [ ! -f "$TARGET" ]; then
-  curl -L -o "$TARGET" "https://storage.googleapis.com/kubernetes-release/release/$TARGET_VERSION/bin/$OS/$CPU_ARCHITECTURE/kubectl"
+  curl -L -o "$TARGET" "https://storage.googleapis.com/kubernetes-release/release/$TARGET_VERSION/bin/$OS/$CPU_ARCHITECTURE/kubectl" > /dev/null 2>&1
   chmod +x "$TARGET"
 fi
 

--- a/k
+++ b/k
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set +xe
 
-KX_PATH="$HOME/.kx"
+KX_PATH="${KX_PATH:-$HOME/.kx}"
 mkdir -p "$KX_PATH/cache"
 
 case "$OSTYPE" in


### PR DESCRIPTION
* added DEBUG ability which runs `set -ex` if the user sets it
* KX_PATH can be configured by the caller but still defaults to what was set before
* adhere to default shellcheck recommendations
* pull the latest version for `kubectl` from Google instead of hard-coding it
* limit output so we can grep like we are used to with native `kubectl`
* support EKS clusters, which have a custom suffix. For example when I do `kubectl version` I get this:
```
❯ ./k version
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.11", GitCommit:"d94a81c724ea8e1ccc9002d89b7fe81d58f89ede", GitTreeState:"clean", BuildDate:"2020-03-12T21:08:59Z", GoVersion:"go1.12.17", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"15+", GitVersion:"v1.15.11-eks-af3caf", GitCommit:"af3caf6136cd355f467083651cc1010a499f59b1", GitTreeState:"clean", BuildDate:"2020-03-27T21:51:36Z", GoVersion:"go1.12.17", Compiler:"gc", Platform:"linux/amd64"}
```